### PR TITLE
Add GitHub Actions workflow to build debug APK

### DIFF
--- a/.github/workflow/build.yml
+++ b/.github/workflow/build.yml
@@ -1,0 +1,30 @@
+name: Build APK
+
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: duo-animation-debug-apk
+          path: app/build/outputs/apk/debug/*.apk


### PR DESCRIPTION
Debug build 😀 Adds a CI workflow that automatically builds a debug APK using Gradle, so contributors can download a ready-to-install build from the Actions tab without setting up Android Studio locally